### PR TITLE
fixed typo, from 'rearangne' to 'rearrange'

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ use {
   -- Methods of detecting the root directory. **"lsp"** uses the native neovim
   -- lsp, while **"pattern"** uses vim-rooter like glob pattern matching. Here
   -- order matters: if one is not detected, the other is used as fallback. You
-  -- can also delete or rearangne the detection methods.
+  -- can also delete or rearrange the detection methods.
   detection_methods = { "lsp", "pattern" },
 
   -- All the patterns used to detect root dir, when **"pattern"** is in

--- a/lua/project_nvim/config.lua
+++ b/lua/project_nvim/config.lua
@@ -9,7 +9,7 @@ M.defaults = {
   -- Methods of detecting the root directory. **"lsp"** uses the native neovim
   -- lsp, while **"pattern"** uses vim-rooter like glob pattern matching. Here
   -- order matters: if one is not detected, the other is used as fallback. You
-  -- can also delete or rearangne the detection methods.
+  -- can also delete or rearrange the detection methods.
   detection_methods = { "lsp", "pattern" },
 
   -- All the patterns used to detect root dir, when **"pattern"** is in


### PR DESCRIPTION
To confirm spelling, see
https://www.merriam-webster.com/dictionary/rearrange